### PR TITLE
Update LineDrawer.m

### DIFF
--- a/Smooth Drawing/LineDrawer.m
+++ b/Smooth Drawing/LineDrawer.m
@@ -81,7 +81,7 @@ typedef struct _LineVertex {
     velocities = [NSMutableArray array];
     circlesPoints = [NSMutableArray array];
 
-    shaderProgram_ = [[CCShaderCache sharedShaderCache] programForKey:kCCShader_PositionColor];
+    self.shaderProgram = [[CCShaderCache sharedShaderCache] programForKey:kCCShader_PositionColor];
     overdraw = 3.0f;
 
     renderTexture = [[CCRenderTexture alloc] initWithWidth:(int)self.contentSize.width height:(int)self.contentSize.height pixelFormat:kCCTexture2DPixelFormat_RGBA8888];


### PR DESCRIPTION
Using self.shaderProgram would retain the variable. Fixes crash in non-ARC projects when the variable gets deallocated.
